### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions_update.yml
+++ b/.github/workflows/actions_update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,11 +49,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@codeql-bundle-20230524
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -80,22 +80,22 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: 7.0.x
 
     - name: Setup MSBuild Path
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v1.3.1
       with:
         msbuild-architecture: x64
 
     - name: Install NuGet client
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@v1.2.0
       with:
         nuget-version: 'latest'
 
     - name: Install Nanoframework Extension
-      uses: nanoframework/nanobuild@v1
+      uses: nanoframework/nanobuild@v1.14
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.githubAuth }}
 
@@ -108,6 +108,6 @@ jobs:
         Configuration: Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@codeql-bundle-20230524
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -20,34 +20,34 @@ jobs:
       solution: 'OpenHalo.sln'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
           
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
 
       - name: Setup MSBuild Path
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1.3.1
         with:
           msbuild-architecture: x64
 
       # https://github.com/NuGet/setup-nuget
       - name: Install NuGet client
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@v1.2.0
         with:
           nuget-version: 'latest'
           
       - name: Install Nanoframework Extension
-        uses: nanoframework/nanobuild@v1
+        uses: nanoframework/nanobuild@v1.14
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.githubAuth }}
           
@@ -55,7 +55,7 @@ jobs:
         run: nuget restore ${{ env.solution }} -ConfigFile nuget.config
         
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update Changelog
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
       - name: Update Changelog
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           commit-message: update changelog
           title: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: nanoframework/nanodu@v1
+        uses: actions/checkout@v4.1.1
+      - uses: nanoframework/nanodu@v1.0.19
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
* **[nanoframework/nanobuild](https://github.com/nanoframework/nanobuild)** published a new release **[v1.14](https://github.com/nanoframework/nanobuild/releases/tag/v1.14)** on 2022-12-27T15:00:29Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2)** on 2023-06-14T01:20:17Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.0.0](https://github.com/actions/setup-java/releases/tag/v4.0.0)** on 2023-11-29T14:29:16Z
* **[nuget/setup-nuget](https://github.com/nuget/setup-nuget)** published a new release **[v1.2.0](https://github.com/NuGet/setup-nuget/releases/tag/v1.2.0)** on 2023-04-11T20:15:21Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.19](https://github.com/nanoframework/nanodu/releases/tag/v1.0.19)** on 2023-02-27T15:35:45Z
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release **[v1.3.1](https://github.com/microsoft/setup-msbuild/releases/tag/v1.3.1)** on 2023-02-07T20:29:12Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.0.0](https://github.com/actions/setup-dotnet/releases/tag/v4.0.0)** on 2023-12-04T14:24:07Z
