### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -55,7 +55,7 @@ jobs:
         run: nuget restore ${{ env.solution }} -ConfigFile nuget.config
         
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3.3.3
+        uses: actions/cache@v4.0.0
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v3.3.3
+        uses: actions/cache@v4.0.0
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
@@ -88,7 +88,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@v4.2.0
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: Build binaries


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.2.0](https://github.com/actions/upload-artifact/releases/tag/v4.2.0)** on 2024-01-18T20:12:17Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.0](https://github.com/actions/cache/releases/tag/v4.0.0)** on 2024-01-16T22:17:55Z
