### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,12 +85,12 @@ jobs:
         dotnet-version: 7.0.x
 
     - name: Setup MSBuild Path
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x64
 
     - name: Install NuGet client
-      uses: nuget/setup-nuget@v1.2.0
+      uses: nuget/setup-nuget@v2.0.0
       with:
         nuget-version: 'latest'
 

--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -36,13 +36,13 @@ jobs:
           distribution: 'zulu' # Alternative distribution options are available.
 
       - name: Setup MSBuild Path
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
 
       # https://github.com/NuGet/setup-nuget
       - name: Install NuGet client
-        uses: nuget/setup-nuget@v1.2.0
+        uses: nuget/setup-nuget@v2.0.0
         with:
           nuget-version: 'latest'
           

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@v6.0.0
         with:
           commit-message: update changelog
           title: Update Changelog


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.0.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.0)** on 2024-01-31T11:17:45Z
* **[nuget/setup-nuget](https://github.com/nuget/setup-nuget)** published a new release **[v2.0.0](https://github.com/NuGet/setup-nuget/releases/tag/v2.0.0)** on 2024-01-30T21:34:31Z
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release **[v2](https://github.com/microsoft/setup-msbuild/releases/tag/v2)** on 2024-01-31T01:06:10Z
