### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -88,7 +88,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4.3.1
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: Build binaries

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - uses: nanoframework/nanodu@v1.0.20
+      - uses: nanoframework/nanodu@v1.0.21
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.21](https://github.com/nanoframework/nanodu/releases/tag/v1.0.21)** on 2024-02-22T00:57:07Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
