### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
@@ -55,7 +55,7 @@ jobs:
         run: nuget restore ${{ env.solution }} -ConfigFile nuget.config
         
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4.0.1
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4.0.1
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.0
+        uses: peter-evans/create-pull-request@v6.0.1
         with:
           commit-message: update changelog
           title: Update Changelog


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.1](https://github.com/actions/cache/releases/tag/v4.0.1)** on 2024-02-29T18:30:59Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.1.0](https://github.com/actions/setup-java/releases/tag/v4.1.0)** on 2024-02-28T05:25:25Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.0.1](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1)** on 2024-02-28T00:33:43Z
