### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.1.0
+        uses: actions/setup-java@v4.2.1
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
@@ -55,7 +55,7 @@ jobs:
         run: nuget restore ${{ env.solution }} -ConfigFile nuget.config
         
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.1
+        uses: peter-evans/create-pull-request@v6.0.2
         with:
           commit-message: update changelog
           title: Update Changelog


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.2.1](https://github.com/actions/setup-java/releases/tag/v4.2.1)** on 2024-03-14T14:29:47Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.2)** on 2024-03-12T14:23:15Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
