### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions_update.yml
+++ b/.github/workflows/actions_update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.4
+      uses: actions/checkout@v4.1.7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -95,7 +95,7 @@ jobs:
         nuget-version: 'latest'
 
     - name: Install Nanoframework Extension
-      uses: nanoframework/nanobuild@v1.14
+      uses: nanoframework/nanobuild@v1.15
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.githubAuth }}
 

--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -20,7 +20,7 @@ jobs:
       solution: 'OpenHalo.sln'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           
@@ -47,7 +47,7 @@ jobs:
           nuget-version: 'latest'
           
       - name: Install Nanoframework Extension
-        uses: nanoframework/nanobuild@v1.14
+        uses: nanoframework/nanobuild@v1.15
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.githubAuth }}
           

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update Changelog
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
       - name: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.4
-      - uses: nanoframework/nanodu@v1.0.21
+        uses: actions/checkout@v4.1.7
+      - uses: nanoframework/nanodu@v1.0.23
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.23](https://github.com/nanoframework/nanodu/releases/tag/v1.0.23)** on 2024-06-12T13:54:40Z
* **[nanoframework/nanobuild](https://github.com/nanoframework/nanobuild)** published a new release **[v1.15](https://github.com/nanoframework/nanobuild/releases/tag/v1.15)** on 2024-06-08T08:44:40Z
