### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,7 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4.0.0
+      uses: actions/setup-dotnet@v4.0.1
       with:
         dotnet-version: 7.0.x
 

--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4.0.1
         with:
           dotnet-version: 7.0.x
 
@@ -88,7 +88,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: Build binaries

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.0.5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           commit-message: update changelog
           title: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
-      - uses: nanoframework/nanodu@v1.0.23
+      - uses: nanoframework/nanodu@v1.0.24
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.24](https://github.com/nanoframework/nanodu/releases/tag/v1.0.24)** on 2024-06-18T00:11:43Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.4](https://github.com/actions/upload-artifact/releases/tag/v4.3.4)** on 2024-07-05T15:15:04Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.0.1](https://github.com/actions/setup-dotnet/releases/tag/v4.0.1)** on 2024-07-09T14:31:19Z
