### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/nanoframework_build.yml
+++ b/.github/workflows/nanoframework_build.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v4.3.0
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
@@ -88,7 +88,7 @@ jobs:
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.4.0
         if: ${{ matrix.configuration == 'Release' }}
         with:
           name: Build binaries

--- a/.github/workflows/nanoframework_changelog.yml
+++ b/.github/workflows/nanoframework_changelog.yml
@@ -18,7 +18,7 @@ jobs:
           ./git-chglog -o CHANGELOG.md
           rm git-chglog
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6.1.0
+        uses: peter-evans/create-pull-request@v7.0.2
         with:
           commit-message: update changelog
           title: Update Changelog

--- a/.github/workflows/nanoframework_dependabot.yml
+++ b/.github/workflows/nanoframework_dependabot.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
-      - uses: nanoframework/nanodu@v1.0.24
+      - uses: nanoframework/nanodu@v1.0.25
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.3.0](https://github.com/actions/setup-java/releases/tag/v4.3.0)** on 2024-09-09T14:25:53Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.2)** on 2024-09-12T11:51:49Z
* **[nanoframework/nanodu](https://github.com/nanoframework/nanodu)** published a new release **[v1.0.25](https://github.com/nanoframework/nanodu/releases/tag/v1.0.25)** on 2024-08-27T08:33:53Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.0](https://github.com/actions/upload-artifact/releases/tag/v4.4.0)** on 2024-08-30T18:10:56Z
