### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.851\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.878\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -8,7 +8,7 @@
   <package id="nanoFramework.Graphics" version="1.2.45" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Graphics.Core" version="1.2.45" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.34" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.851" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.878" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.203" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Networking.Sntp" version="1.6.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.ResourceManager" version="1.2.32" targetFramework="netnanoframework10" />


### PR DESCRIPTION
Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.851 to 1.2.878</br>
[version update]

### :warning: This is an automated update. :warning:
