### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.909\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.938\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
@@ -104,8 +104,8 @@
     <Reference Include="System.Device.Pwm, Version=1.1.23.36628, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.Pwm.1.1.23\lib\System.Device.Pwm.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.139.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.139\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.141.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.141\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.IO.FileSystem.1.1.87\lib\System.IO.FileSystem.dll</HintPath>
@@ -116,11 +116,11 @@
     <Reference Include="System.Math, Version=1.5.116.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Math.1.5.116\lib\System.Math.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.1.11.47\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.50.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.1.11.50\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.200.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.Http.1.5.200\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.203.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.Http.1.5.203\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -8,7 +8,7 @@
   <package id="nanoFramework.Graphics" version="1.2.45" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Graphics.Core" version="1.2.45" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.37" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.909" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.938" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.203" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Networking.Sntp" version="1.6.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.ResourceManager" version="1.2.32" targetFramework="netnanoframework10" />
@@ -18,12 +18,12 @@
   <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.23" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.139" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.141" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.87" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.5.116" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.47" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.200" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.203" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnanoframework10" />
   <package id="TekuSP.Drivers.CST816D" version="0.4.729" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.909 to 1.2.938</br>Bumps nanoFramework.System.Device.Wifi from 1.5.139 to 1.5.141</br>Bumps nanoFramework.System.Net from 1.11.47 to 1.11.50</br>Bumps nanoFramework.System.Net.Http from 1.5.200 to 1.5.203</br>
[version update]

### :warning: This is an automated update. :warning:
