### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -119,8 +119,8 @@
     <Reference Include="System.Net, Version=1.11.50.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Net.1.11.50\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.204.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.Http.1.5.204\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.206.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.Http.1.5.206\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -23,7 +23,7 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.5.116" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.204" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.206" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnanoframework10" />
   <package id="TekuSP.Drivers.CST816D" version="0.4.729" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.System.Net.Http from 1.5.204 to 1.5.206</br>
[version update]

### :warning: This is an automated update. :warning:
