### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.951\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>packages\nanoFramework.Iot.Device.DhcpServer.1.2.965\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
@@ -65,17 +65,17 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Graphics, Version=1.2.45.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Graphics.1.2.45\lib\nanoFramework.Graphics.dll</HintPath>
+    <Reference Include="nanoFramework.Graphics, Version=1.2.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Graphics.1.2.52\lib\nanoFramework.Graphics.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Graphics.Core, Version=1.2.45.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Graphics.Core.1.2.45\lib\nanoFramework.Graphics.Core.dll</HintPath>
+    <Reference Include="nanoFramework.Graphics.Core, Version=1.2.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Graphics.Core.1.2.52\lib\nanoFramework.Graphics.Core.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Hardware.Esp32, Version=1.6.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.Hardware.Esp32.1.6.37\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.210.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Json.2.2.210\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.212.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Json.2.2.212\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Networking.Sntp, Version=1.6.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.Networking.Sntp.1.6.42\lib\nanoFramework.Networking.Sntp.dll</HintPath>
@@ -89,8 +89,8 @@
     <Reference Include="nanoFramework.Runtime.Native, Version=1.7.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.Runtime.Native.1.7.11\lib\nanoFramework.Runtime.Native.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Collections.1.5.75\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
@@ -119,8 +119,8 @@
     <Reference Include="System.Net, Version=1.11.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Net.1.11.52\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.207.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.Http.1.5.207\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.208.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.Http.1.5.208\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -5,16 +5,16 @@
   <package id="MakoIoT.Device.Utilities.String" version="1.0.44.38123" targetFramework="netnanoframework10" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Graphics" version="1.2.45" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Graphics.Core" version="1.2.45" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Graphics" version="1.2.52" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Graphics.Core" version="1.2.52" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.37" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.951" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.210" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.965" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.212" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Networking.Sntp" version="1.6.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.ResourceManager" version="1.2.32" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.23" targetFramework="netnano1.0" />
@@ -23,7 +23,7 @@
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.5.116" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.52" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.207" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.208" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnanoframework10" />
   <package id="TekuSP.Drivers.CST816D" version="0.4.729" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Graphics from 1.2.45 to 1.2.52</br>Bumps nanoFramework.Graphics.Core from 1.2.45 to 1.2.52</br>Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.951 to 1.2.965</br>Bumps nanoFramework.Json from 2.2.210 to 2.2.212</br>Bumps nanoFramework.System.Collections from 1.5.67 to 1.5.75</br>Bumps nanoFramework.System.Net.Http from 1.5.207 to 1.5.208</br>
[version update]

### :warning: This is an automated update. :warning:
