### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -104,8 +104,8 @@
     <Reference Include="System.Device.Pwm, Version=1.1.23.36628, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.Pwm.1.1.23\lib\System.Device.Pwm.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.147.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.147\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.149.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.149\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.93.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.IO.FileSystem.1.1.93\lib\System.IO.FileSystem.dll</HintPath>
@@ -116,11 +116,11 @@
     <Reference Include="System.Math, Version=1.5.116.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Math.1.5.116\lib\System.Math.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.1.11.54\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.60.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.1.11.60\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.209.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.Http.1.5.209\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.210.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.Http.1.5.210\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -18,12 +18,12 @@
   <package id="nanoFramework.System.Device.Gpio" version="1.1.62" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.23" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.147" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.149" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.93" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.5.116" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.54" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.209" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.11.60" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.210" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnanoframework10" />
   <package id="TekuSP.Drivers.CST816D" version="0.4.729" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.System.Device.Wifi from 1.5.147 to 1.5.149</br>Bumps nanoFramework.System.Net from 1.11.54 to 1.11.60</br>Bumps nanoFramework.System.Net.Http from 1.5.209 to 1.5.210</br>
[version update]

### :warning: This is an automated update. :warning:
