### PR TITLE
Update 8 NuGet dependencies

### DIFF
--- a/OpenHalo.nfproj
+++ b/OpenHalo.nfproj
@@ -65,14 +65,14 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Graphics, Version=1.2.53.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Graphics.1.2.53\lib\nanoFramework.Graphics.dll</HintPath>
+    <Reference Include="nanoFramework.Graphics, Version=1.2.55.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Graphics.1.2.55\lib\nanoFramework.Graphics.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Graphics.Core, Version=1.2.53.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Graphics.Core.1.2.53\lib\nanoFramework.Graphics.Core.dll</HintPath>
+    <Reference Include="nanoFramework.Graphics.Core, Version=1.2.55.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Graphics.Core.1.2.55\lib\nanoFramework.Graphics.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hardware.Esp32, Version=1.6.40.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Hardware.Esp32.1.6.40\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    <Reference Include="nanoFramework.Hardware.Esp32, Version=1.6.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Hardware.Esp32.1.6.42\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Json, Version=2.2.213.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.Json.2.2.213\lib\nanoFramework.Json.dll</HintPath>
@@ -83,8 +83,8 @@
     <Reference Include="nanoFramework.ResourceManager, Version=1.2.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.ResourceManager.1.2.32\lib\nanoFramework.ResourceManager.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.11.37\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.39.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.11.39\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.7.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.Runtime.Native.1.7.11\lib\nanoFramework.Runtime.Native.dll</HintPath>
@@ -95,8 +95,8 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Gpio, Version=1.1.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Gpio.1.1.62\lib\System.Device.Gpio.dll</HintPath>
+    <Reference Include="System.Device.Gpio, Version=1.1.64.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.1.64\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
     <Reference Include="System.Device.I2c, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
@@ -104,11 +104,11 @@
     <Reference Include="System.Device.Pwm, Version=1.1.23.36628, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.Pwm.1.1.23\lib\System.Device.Pwm.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.149.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.149\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.150.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Wifi.1.5.150\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.93.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.IO.FileSystem.1.1.93\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.IO.FileSystem.1.1.94\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>
@@ -119,8 +119,8 @@
     <Reference Include="System.Net, Version=1.11.60.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Net.1.11.60\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.210.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Net.Http.1.5.210\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.212.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Net.Http.1.5.212\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -5,25 +5,25 @@
   <package id="MakoIoT.Device.Utilities.String" version="1.0.44.38123" targetFramework="netnanoframework10" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Graphics" version="1.2.53" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Graphics.Core" version="1.2.53" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Hardware.Esp32" version="1.6.40" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Graphics" version="1.2.55" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Graphics.Core" version="1.2.55" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.987" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.213" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Networking.Sntp" version="1.6.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.ResourceManager" version="1.2.32" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.37" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.39" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.1.62" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.64" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.23" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.149" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.93" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.150" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.94" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.5.116" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.60" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.210" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.212" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnanoframework10" />
   <package id="TekuSP.Drivers.CST816D" version="0.4.729" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Graphics from 1.2.53 to 1.2.55</br>Bumps nanoFramework.Graphics.Core from 1.2.53 to 1.2.55</br>Bumps nanoFramework.Hardware.Esp32 from 1.6.40 to 1.6.42</br>Bumps nanoFramework.Runtime.Events from 1.11.37 to 1.11.39</br>Bumps nanoFramework.System.Device.Gpio from 1.1.62 to 1.1.64</br>Bumps nanoFramework.System.Device.Wifi from 1.5.149 to 1.5.150</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.93 to 1.1.94</br>Bumps nanoFramework.System.Net.Http from 1.5.210 to 1.5.212</br>
[version update]

### :warning: This is an automated update. :warning:
